### PR TITLE
Updated doAnimationWork to handle unsubscribing events from element

### DIFF
--- a/src/knockout.animate.js
+++ b/src/knockout.animate.js
@@ -18,10 +18,10 @@
         }
     }
 
-    function removePrefixedEvent(element, type) {
+    function removePrefixedEvent(element, type, callback) {
         for (var p = 0; p < pfx.length; p++) {
             if (!pfx[p]) type = type.toLowerCase();
-            element.removeEventListener(pfx[p]+type);
+            element.removeEventListener(pfx[p]+type, callback);
         }
     }
 
@@ -46,8 +46,10 @@
         addClass(element, baseAnimateClass);
         addClass(element, animation);
 
-        addPrefixedEvent(element, "AnimationEnd", function(event){
-            removePrefixedEvent(element, "AnimationEnd");
+        var eventSubscription = null;
+
+        removeCallback = function(event){
+            removePrefixedEvent(element, "AnimationEnd", eventSubscription);
 
             removeClass(element, baseAnimateClass);
             removeClass(element, animation);
@@ -55,7 +57,9 @@
             if (typeof callback === 'function'){
                 callback(event, state);
             }
-        });
+        };
+
+        addPrefixedEvent(element, "AnimationEnd", eventSubscription);
     }
 
     ko.bindingHandlers.animate = {

--- a/src/knockout.animate.js
+++ b/src/knockout.animate.js
@@ -48,7 +48,7 @@
 
         var eventSubscription = null;
 
-        removeCallback = function(event){
+        eventSubscription = function(event){
             removePrefixedEvent(element, "AnimationEnd", eventSubscription);
 
             removeClass(element, baseAnimateClass);


### PR DESCRIPTION
Animations didn't work on IE and Firefox, as removeEventListener for element required callback as non-optional parameter. Updated doAnimationWork to handle unsubscribing events from element
